### PR TITLE
Fix: Check utf-8 BOM at the beginning of the OPF stream

### DIFF
--- a/src/EPUB2JSON/Parse.hs
+++ b/src/EPUB2JSON/Parse.hs
@@ -7,6 +7,7 @@ where
 
 import qualified Codec.Archive.Zip as Z
 import qualified Data.Aeson as A
+import qualified Data.ByteString.Lazy.Char8 as LB
 import qualified Data.Map as M
 import Data.Text (pack, unpack)
 import qualified Data.Text.Encoding as T
@@ -46,8 +47,14 @@ readXmlFromArchive relativePath archive =
 
 parseXml :: FilePath -> LByteString -> Either EPUBParseException X.Document
 parseXml relativePath src =
-  either (Left . EPUBXmlDecodeError relativePath) Right (LT.decodeUtf8' src)
+  either (Left . EPUBXmlDecodeError relativePath) Right (LT.decodeUtf8' (checkBom src))
     >>= either (Left . EPUBXmlParseError relativePath) Right . X.parseText X.def
+
+checkBom :: LByteString -> LByteString
+checkBom lbs =
+  if LB.isPrefixOf (LB.pack "\xef\xbb\xbf") lbs
+    then LB.drop 3 lbs
+    else lbs
 
 getOpfPath :: C.Cursor -> Either EPUBParseException Text
 getOpfPath =


### PR DESCRIPTION
I've found some EPUB files that contain a BOM in an OPF file. To address this issue, check for the BOM (`EF BB BF`) at the beginning of the stream and drop the first three bytes if it is found.